### PR TITLE
Changed this.props.elementBox.top <=0 to <-1

### DIFF
--- a/components/SideBlock.jsx
+++ b/components/SideBlock.jsx
@@ -34,10 +34,16 @@ import ReactDOM from 'react-dom';
 
        let isCurrent = this.props.elementBox && this.props.elementBox.top!==undefined
        && (
-         this.props.elementBox.top <=0
+         this.props.elementBox.top <-1
          && this.props.elementHeight+this.props.elementBox.top>=0
          && this.props.elementHeight != this.props.windowHeight
        );
+       console.log("elementBox: ", this.props.elementBox);
+       console.log(this.props.elementBox.top);
+       console.log(this.props.elementHeight);
+       console.log(this.props.windowHeight);
+       console.log("isCurrent: ", isCurrent);
+
        let isAtEnd = this.props.elementBox && this.props.elementBox.bottom<this.props.windowHeight;
 
 


### PR DESCRIPTION
Hi,

This is my second try at a pull request :) I created a new branch, fetched your repo again and cherrypicked the right commit. I keep on learning...

With this change the position of text in the projects sideblock stays relative so when you scroll up (while a project is opened) the text won't be in your picture. And also when you close the project somehow (I haven't figured out why) the position of the text stays absolute instead of returning to relative.